### PR TITLE
feat : 세션 기반 카카오 OAuth 로그인

### DIFF
--- a/src/main/java/com/underrRndezvous/backend/controller/TestController.java
+++ b/src/main/java/com/underrRndezvous/backend/controller/TestController.java
@@ -1,20 +1,57 @@
+
 package com.underrRndezvous.backend.controller;
 
 import com.underrRndezvous.backend.dto.KakaoLoginRequest;
+import com.underrRndezvous.backend.dto.KakaoUserInfo;
+import com.underrRndezvous.backend.service.KakaoService;
+import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.Map;
 
 
 @RestController
+@RequestMapping("/oauth/kakao")
 @Slf4j
 public class TestController {
+    private final KakaoService kakaoService;
 
-    @PostMapping("/oauth/kakao/callback")
-    public void kakaoLoginTest(@RequestBody KakaoLoginRequest kakaoLoginRequest) {
-        log.info("kakaoLoginRequest={}", kakaoLoginRequest.getCode());
+    public TestController(KakaoService kakaoService) {
+        this.kakaoService = kakaoService;
+    }
+
+    @PostMapping("/callback")
+    public ResponseEntity<Object> kakaoLoginTest(@RequestBody KakaoLoginRequest kakaoLoginRequest, HttpSession session) {
+        try {
+            // 1) 카카오에서 유저 정보 가져오기
+            KakaoUserInfo kakaoUser = kakaoService.processKakaoLogin(kakaoLoginRequest.getCode());
+            log.info("kakaoUser={}", kakaoUser);
+
+            // 2) 세션에 KakaoUserInfo 저장
+            session.setAttribute("LOGIN_USER_ID", kakaoUser.getId());
+            session.setAttribute("LOGIN_USER_NICKNAME", kakaoUser.getNickname());
+
+            // 3) 프론트에 바로 DTO 반환
+            return ResponseEntity.ok(kakaoUser);
+
+        } catch (HttpClientErrorException.BadRequest ex) {
+            log.error("인가 코드 오류", ex);
+            return ResponseEntity
+                    .badRequest()
+                    .body(Map.of("error", "인가 코드가 유효하지 않습니다."));
+        } catch (Exception ex) {
+            log.error("카카오 로그인 처리 중 예외 발생", ex);
+            return ResponseEntity
+                    .status(500)
+                    .body(Map.of("error", "서버 내부 오류가 발생했습니다."));
+
+        }
     }
 
 }
-

--- a/src/main/java/com/underrRndezvous/backend/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/underrRndezvous/backend/dto/KakaoLoginRequest.java
@@ -2,9 +2,11 @@ package com.underrRndezvous.backend.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @NoArgsConstructor
 @Getter
+@Setter
 public class KakaoLoginRequest {
     private String code;
 }

--- a/src/main/java/com/underrRndezvous/backend/dto/KakaoOAuthToken.java
+++ b/src/main/java/com/underrRndezvous/backend/dto/KakaoOAuthToken.java
@@ -1,0 +1,14 @@
+package com.underrRndezvous.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoOAuthToken {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+}

--- a/src/main/java/com/underrRndezvous/backend/dto/KakaoUserInfo.java
+++ b/src/main/java/com/underrRndezvous/backend/dto/KakaoUserInfo.java
@@ -1,0 +1,12 @@
+package com.underrRndezvous.backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfo {
+    private Long id;
+    private String nickname;
+    private String email;
+}

--- a/src/main/java/com/underrRndezvous/backend/service/KakaoService.java
+++ b/src/main/java/com/underrRndezvous/backend/service/KakaoService.java
@@ -1,0 +1,83 @@
+package com.underrRndezvous.backend.service;
+
+import com.underrRndezvous.backend.dto.KakaoOAuthToken;
+import com.underrRndezvous.backend.dto.KakaoUserInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+public class KakaoService {
+    @Value("${kakao.client-id}")           private String clientId;
+    @Value("${kakao.redirect-uri}")        private String redirectUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // 1) 인가 코드로 액세스 토큰 발급
+    public String getAccessToken(String code) {
+        String tokenUrl = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String,String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type",   "authorization_code");
+        params.add("client_id",    clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code",         code);
+
+        HttpEntity<MultiValueMap<String,String>> request = new HttpEntity<>(params, headers);
+        KakaoOAuthToken response = restTemplate.postForObject(tokenUrl, request, KakaoOAuthToken.class);
+
+        return response.getAccessToken();
+    }
+
+    // 2) 액세스 토큰으로 유저 정보 조회
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        String userUrl = "https://kapi.kakao.com/v2/user/me";
+
+        // 헤더에 Bearer 토큰 세팅
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        // ParameterizedTypeReference 로 제네릭 정보 보존
+        ResponseEntity<Map<String, Object>> responseEntity =
+                restTemplate.exchange(
+                        userUrl,
+                        HttpMethod.GET,
+                        request,
+                        new ParameterizedTypeReference<Map<String, Object>>() {}
+                );
+
+        Map<String, Object> response = responseEntity.getBody();
+
+        // 필요한 정보 꺼내기
+        Long id = ((Number) response.get("id")).longValue();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) response.get("properties");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> kakaoAccount = (Map<String, Object>) response.get("kakao_account");
+
+        // DTO에 담아서 반환
+        KakaoUserInfo info = new KakaoUserInfo();
+        info.setId(id);
+        info.setNickname((String) properties.get("nickname"));
+        info.setEmail((String) kakaoAccount.get("email"));
+
+        return info;
+    }
+
+    // 통합 메서드
+    public KakaoUserInfo processKakaoLogin(String code) {
+        String token = getAccessToken(code);
+        return getUserInfo(token);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,11 @@ spring:
 #       mode: always
 # #      schema-locations: classpath:
 # #        data-locations: classpath:
+
+kakao:
+  client-id: 8c726ec0ff9d015553a536f3bfa6f551
+  redirect-uri: http://localhost:3000/redirect
+
 logging:
   level:
     org:


### PR DESCRIPTION
## 주요 구현 사항
**1. KakaoService** 
- 인가 코드를 카카오 API 에 전달해 토큰을 발급
- 발급된 토큰으로 사용자 정보(id, nickname, etc) 조회

**2. TestController**
- 세션 기반으로 로그인 상태 관리
- 인가 코드 유효성 오류 & 서버 에러 예외처리

## 테스트 방법
시크릿 모드에서 카카오 로그인 
(일반 모드에서는 쿠키 남아있으면 자동 로그인) 

## 향후 작업
사용자 DB 저장 및 기존 회원 여부 확인 로직 