### PR TITLE
refactor : 단순 평균 대신 구면 중간 위치 계산 적용

### DIFF
--- a/src/main/java/com/underrRndezvous/backend/config/DataLoader.java
+++ b/src/main/java/com/underrRndezvous/backend/config/DataLoader.java
@@ -34,7 +34,7 @@ public class DataLoader implements ApplicationRunner {
             List<Location> locations = locDtos.stream()
                     .map(dto -> new Location(
                             null,
-                            dto.getSido(),
+                            dto.getSi(),
                             dto.getGu(),
                             dto.getDong(),
                             dto.getLat(),

--- a/src/main/java/com/underrRndezvous/backend/controller/AreaRecommendationController.java
+++ b/src/main/java/com/underrRndezvous/backend/controller/AreaRecommendationController.java
@@ -22,8 +22,10 @@ public class AreaRecommendationController {
     @GetMapping("/recommend/{meetingId}")
     public List<AreaResponse> recommendAreas(
             @PathVariable Long meetingId,
-            @RequestParam(defaultValue = "3") int limit
-    ) {
+            @RequestParam(defaultValue = "3")
+            int limit
+    )
+    {
         log.info("recommendAreas called for meetingId={}, limit={}", meetingId, limit);
         return recommendationService.recommendByMeeting(meetingId, limit);
     }

--- a/src/main/java/com/underrRndezvous/backend/domain/user/Location.java
+++ b/src/main/java/com/underrRndezvous/backend/domain/user/Location.java
@@ -39,7 +39,6 @@ public class Location {
     @OneToMany(mappedBy = "location", cascade = CascadeType.ALL)
     private List<MeetingUser> meetingUsers = new ArrayList<>();
 
-    // 생성자 (필요에 따라 추가)
     public Location(Long locationId, String si, String gu, String dong,
                     Double latitude, Double longitude) {
         this.locationId = locationId;

--- a/src/main/java/com/underrRndezvous/backend/dto/LocationDto.java
+++ b/src/main/java/com/underrRndezvous/backend/dto/LocationDto.java
@@ -7,7 +7,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class LocationDto {
-    private String sido;
+    @JsonProperty("sido")
+    private String si;
+
     private String gu;
     private String dong;
 

--- a/src/main/java/com/underrRndezvous/backend/service/AreaRecommendationService.java
+++ b/src/main/java/com/underrRndezvous/backend/service/AreaRecommendationService.java
@@ -25,24 +25,17 @@ public class AreaRecommendationService {
         this.areaRepo        = areaRepo;
     }
 
-    /**
-     * 모임(meetingId) 참가자들의 평균 위치에서 가장 가까운 핫플 3곳을 반환
-     */
+
+    // 모임(meetingId) 참가자들의 중간 위치에서 가장 가까운 핫플 3곳을 반환
     public List<AreaResponse> recommendByMeeting(Long meetingId, int limit) {
-        List<MeetingUser> participants =
-                meetingUserRepo.findByMeetingMeetingId(meetingId);
+        List<MeetingUser> participants = meetingUserRepo.findByMeetingMeetingId(meetingId);
         if (participants.isEmpty()) {
-            throw new NotExistBaseException(
-                    "Meeting or participants not found: " + meetingId
-            );
+            throw new NotExistBaseException("Meeting or participants not found: " + meetingId);
         }
 
-        double avgLat = participants.stream()
-                .mapToDouble(mu -> mu.getLocation().getLatitude())
-                .average().orElseThrow();
-        double avgLng = participants.stream()
-                .mapToDouble(mu -> mu.getLocation().getLongitude())
-                .average().orElseThrow();
+        double[] midpoint = calculateGeographicMidpoint(participants);
+        double midLat = midpoint[0];
+        double midLng = midpoint[1];
 
         return areaRepo.findAll().stream()
                 .map(area -> new AreaResponse(
@@ -50,13 +43,40 @@ public class AreaRecommendationService {
                         area.getAreaName(),
                         area.getLatitude(),
                         area.getLongitude(),
-                        haversine(avgLat, avgLng,
+                        haversine(midLat, midLng,
                                 area.getLatitude(), area.getLongitude())
                 ))
                 .sorted(Comparator.comparingDouble(AreaResponse::getDistance))
                 .limit(limit)
                 .collect(Collectors.toList());
     }
+
+
+    // 지구 곡면 위 참가자들의 중간 지점을 계산
+    private double[] calculateGeographicMidpoint(List<MeetingUser> participants) {
+        double x = 0, y = 0, z = 0;
+
+        for (MeetingUser mu : participants) {
+            double lat = Math.toRadians(mu.getLocation().getLatitude());
+            double lon = Math.toRadians(mu.getLocation().getLongitude());
+
+            x += Math.cos(lat) * Math.cos(lon);
+            y += Math.cos(lat) * Math.sin(lon);
+            z += Math.sin(lat);
+        }
+
+        int total = participants.size();
+        x /= total;
+        y /= total;
+        z /= total;
+
+        double hyp = Math.sqrt(x * x + y * y);
+        double midLat = Math.toDegrees(Math.atan2(z, hyp));
+        double midLng = Math.toDegrees(Math.atan2(y, x));
+
+        return new double[]{midLat, midLng};
+    }
+
 
     private static final double R = 6371;
     private double haversine(double lat1, double lon1,


### PR DESCRIPTION
## 주요 구현 사항
참가자들의 단순 위도경도 평균값이 아닌 라디안으로 변환한 뒤 3D Cartesian 좌표로 변환하여 위도경도 평균값 계산

**<로직 흐름>**
findByMeetingMeetingId 로 모임 참가자들 조회
참가자들의 위도 경도 구면 중간점 계산 -> 평균 위도, 경도값 추출
Area(핫플 지역) 데이터를 순회하며 각 area 와 중간점 사이를 haversine 공식을 이용해 거리(distance) 계산
구해진 distance 를 기준으로 상위 3개 area(핫플지역) 반환
## 실행 결과
**모임을 생성하지 않고 중간 지역 추천 api 를 실행한 경우**
<img width="629" height="931" alt="image" src="https://github.com/user-attachments/assets/fae9a614-1784-4a32-b13d-45fdfa8ac44d" />

**중간 지역 추천 api 실행 결과**
<img width="628" height="1351" alt="image" src="https://github.com/user-attachments/assets/d51bdb77-e74e-4891-be50-b9d009d93ef1" />
-> 전 로직과 비교했을 때, 지역 추천에 차이는 없으나 distance 가 미약하게 차이 남.

